### PR TITLE
Allow lists to be used as dimension values

### DIFF
--- a/knoema/data_reader.py
+++ b/knoema/data_reader.py
@@ -55,7 +55,7 @@ class DataReader(object):
                 time_range = value
                 continue
 
-            splited_values = value.split(';')
+            splited_values = value.split(';') if isinstance(value, str) else value
             if definition.isequal_strings_ignorecase(name, 'frequency'):
                 pivotreq.frequencies = splited_values
                 continue

--- a/tests/test_knoema.py
+++ b/tests/test_knoema.py
@@ -100,7 +100,7 @@ class TestKnoemaClient(unittest.TestCase):
     def test_getdata_multiseries_singlefrequency_by_member_id(self):
         """The method is testing getting mulitple series with one frequency by dimension member ids"""
 
-        data_frame = knoema.get('MEI_BTS_COS_2015', location='AT;AU', subject='BSCI', measure='blsa', frequency='Q')
+        data_frame = knoema.get('MEI_BTS_COS_2015', location=['AT', 'AU'], subject='BSCI', measure='blsa', frequency='Q')
         self.assertEqual(data_frame.shape[0], 205)
         self.assertEqual(data_frame.shape[1], 2)
 


### PR DESCRIPTION
Just another feature request for convenience. It's a bit strange to force the user to flatten everything into a string, only for your client code to split it out into a list again.