### PR TITLE
PD-4481 Update pandas library version to work with Python package and recent Python versions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Official Python package for Knoema's API
 ========================================
 
-This is the official documentation for Knoema's Python Package. The package can be used for obtaining data from the datasets from the site knoema.com and uploading data to datasets. This package is compatible with Python v3.x+.
+This is the official documentation for Knoema's Python Package. The package can be used for obtaining data from the datasets from the site knoema.com and uploading data to datasets. This package is compatible with Python v3.9+.
 
 ************
 Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "knoema"
+version = "1.3.0"
+authors = [
+  { name="Knoema", email="info@knoema.com" },
+]
+description = "Official Python package for Knoema's API"
+readme = "README.rst"
+license = {file = "LICENSE"}
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python :: 3 :: Only",
+    "License :: OSI Approved :: MIT License",
+    "Development Status :: 5 - Production/Stable",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+  "pandas==2.2.2",
+  "pytest-shutil==1.7.0"
+]
+keywords = ["API", "knoema"]
+
+[project.urls]
+Homepage = "https://github.com/Knoema/knoema-python-driver"
+Repository = "https://github.com/Knoema/knoema-python-driver.git"
+Issues = "https://github.com/Knoema/knoema-python-driver/issues"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 setup(
   name = 'knoema',
   packages = ['knoema'],
-  version = '1.2.52',
+  version = '1.3.0',
   description = "Official Python package for Knoema's API",
   long_description=readme(),
   author = 'Knoema',
@@ -16,5 +16,5 @@ setup(
   url = 'https://github.com/Knoema/knoema-python-driver',
   keywords = ['API', 'knoema'],
   classifiers = ['Development Status :: 5 - Production/Stable', 'Programming Language :: Python :: 3 :: Only'],
-  install_requires=['pandas==1.3.2', 'pytest-shutil==1.7.0']
+  install_requires=['pandas==2.2.2', 'pytest-shutil==1.7.0']
 )


### PR DESCRIPTION
Our Python API doesn’t work with Python 3.10 or later versions. 

```
pip install pandas==1.3.2
Defaulting to user installation because normal site-packages is not writeable
Collecting pandas==1.3.2
  Downloading pandas-1.3.2.tar.gz (4.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.7/4.7 MB 2.9 MB/s eta 0:00:00
  Installing build dependencies ... error
  error: subprocess-exited-with-error
  × pip subprocess to install build dependencies did not run successfully.
```